### PR TITLE
support html5 urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ lib-cov
 *.pid
 *.gz
 .DS_Store
+.idea
 
 pids
 logs

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ This plugin will store all prerendered pages into a filesystem hierarchy.
 For example: 
 
 url http://domain.lo/?_escaped_fragment_=/en/about - will be saved in CACHE_ROOT_DIR/en/about/___  
-url http://domain.lo/?_escaped_fragment_=/en/main/path/blah - will be saved in CACHE_ROOT_DIR/en/main/path/blah/___
+url http://domain.lo/en/about?_escaped_fragment_= - will be saved in CACHE_ROOT_DIR/en/about/___  
+url http://domain.lo/?_escaped_fragment_=/en/main/path/blah - will be saved in CACHE_ROOT_DIR/en/main/path/blah/___  
+url http://domain.lo/en/main/path/blah?_escaped_fragment_= - will be saved in CACHE_ROOT_DIR/en/main/path/blah/___
 
 and etc
 

--- a/lib/fileCache.js
+++ b/lib/fileCache.js
@@ -3,7 +3,9 @@
  */
 
 var cache_manager = require('cache-manager');
+var url = require('url');
 var fs = require('node-fs');
+var pathUtils = require('path');
 
 module.exports = {
     init: function() {
@@ -46,9 +48,10 @@ var file_cache = {
         var request_url = key.split('#!')[1];
 
         if(typeof request_url !== "undefined") {
-            path = path + request_url + '/' + filename;
+            path = pathUtils.join(path, request_url, '/', filename);
         } else {
-            path = path + '/' + filename;
+            var reqUrl = url.parse(key);
+            path = pathUtils.join(path, reqUrl.pathname, '/', filename);
         }
 
         fs.exists(path, function(exists){
@@ -75,17 +78,18 @@ var file_cache = {
         var request_url = key.split('#!')[1];
 
         if(typeof request_url !== "undefined") {
-            path = path + request_url;
-        }
+            path = pathUtils.join(path, request_url);
 
+        } else {
+            var reqUrl = url.parse(key);
+            path = pathUtils.join(path, reqUrl.pathname);
+        }
         fs.exists(path, function(exists){
             if (exists === false) {
                 fs.mkdirSync(path, '0777',true);
             }
-            fs.writeFile(path + '/' + filename, value, callback);
-
+            fs.writeFile(pathUtils.join(path, '/', filename), value, callback);
         });
-
     }
 };
 


### PR DESCRIPTION
My app uses urls http://domain.lo/, http://domain.lo/en/about etc, without hashbangs, but cache always stores into root file ___
When my app use  meta name="fragment" content="!" prerender adds ?_escaped_fragment_= at the end of the url

The PR add support for next examples: 
 url http://domain.lo/en/about?_escaped_fragment_= - will be saved in CACHE_ROOT_DIR/en/about/___
 url http://domain.lo/en/main/path/blah?_escaped_fragment_= will be saved in CACHE_ROOT_DIR/en/main/path/blah/___
